### PR TITLE
[Opensearch SDK] Add highlight field on type SearchInput

### DIFF
--- a/packages/opensearch-sdk/src/types.ts
+++ b/packages/opensearch-sdk/src/types.ts
@@ -58,6 +58,7 @@ export type SearchInput = {
     timeout?: any;
     version?: boolean;
     urlParams?: any;
+    highlight?: any;
 };
 export type SearchAllIndicesInput = {
     doc_value_fields?: any[];


### PR DESCRIPTION
We would like to use this feature when using a match query, therefore the `SearchInput` must contain a `highlight` field
https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html

Find below how I am intending to use the query searchIndex :
![image](https://user-images.githubusercontent.com/74357383/180736061-45badaa7-002e-41d6-9d12-9b0e8c081409.png)
